### PR TITLE
[codex] Document negative dependency positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,8 @@ Liste des champs propres au type de règle de dépendance :
 - positionStart : `optionnel` / de type nombre — début de l’intervalle d’occurrences de sous-zones à récupérer.
 - positionEnd : `optionnel` / de type nombre — fin de l’intervalle d’occurrences de sous-zones à récupérer.
 
+- `position`, `positionStart` et `positionEnd` acceptent aussi des index negatifs (`-1` = derniere occurrence, `-2` = avant-derniere, etc.).
+
 Remarque :
 - `positionStart` et `positionEnd` peuvent servir à exclure une occurrence et définir deux segments.  
   Exemple : pour récupérer 0 à 2 puis 4 jusqu’à la fin (en excluant 3), renseigner `positionStart = 4` et `positionEnd = 2`.


### PR DESCRIPTION
## What changed
- document that dependency \position\, \positionStart\, and \positionEnd\ accept negative indexes

## Why
The API and README needed to be aligned on the support for \-1\ and other negative occurrence indexes.

## Validation
- consistency checked against the API DTO and tests in qualimarc-api